### PR TITLE
Implement ChatApi sending and automatic routing

### DIFF
--- a/Api.csproj
+++ b/Api.csproj
@@ -7,6 +7,7 @@
     <Nullable>Enable</Nullable>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>CA1812</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Encoder.cs
+++ b/Encoder.cs
@@ -8,13 +8,11 @@ using System.Threading.Tasks;
 
 namespace NosAyudamos
 {
-    public class Encoder
+    class Encoder
     {
         [FunctionName("encode")]
         public async Task<IActionResult> EncodeAsync([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "base62/encode")] HttpRequest req)
         {
-            Contract.Assert(req != null);
-
             using var reader = new StreamReader(req.Body);
             var body = await reader.ReadToEndAsync();
 
@@ -27,8 +25,6 @@ namespace NosAyudamos
         [FunctionName("decode")]
         public async Task<IActionResult> DecodeAsync([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "base62/decode")] HttpRequest req)
         {
-            Contract.Assert(req != null);
-
             using var reader = new StreamReader(req.Body);
             var body = await reader.ReadToEndAsync();
 

--- a/Models/Message.cs
+++ b/Models/Message.cs
@@ -1,21 +1,23 @@
-using System.Text.Json;
+using System;
+using System.Linq;
 
 namespace NosAyudamos
 {
-    public class Message
+    class Message
     {
-        public string? From { get; set; }
-        public string? Body { get; set; }
-        public string? To { get; set; }
+        public string From { get; set; }
+        public string Body { get; set; }
+        public string To { get; set; }
 
         public Message(string from, string body, string to) => (From, Body, To) = (from, body, to);
 
-        internal Message() { }
-
-        public static Message Create(string json) => JsonSerializer.Deserialize<Message>(json, new JsonSerializerOptions
+        public static Message Create(string payload)
         {
-            AllowTrailingCommas = true,
-            PropertyNameCaseInsensitive = true
-        });
+            var values = payload.Split('&', StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Split('='))
+                .ToDictionary(x => x[0], x => x[1]);
+
+            return new Message(values[nameof(From)], values[nameof(Body)], values[nameof(To)]);
+        }
     }
 }

--- a/Services/IBlobStorage.cs
+++ b/Services/IBlobStorage.cs
@@ -10,16 +10,11 @@ namespace NosAyudamos
         Task UploadAsync(byte[] bytes, string containerName, string blobName);
     }
 
-    public class BlobStorage : IBlobStorage
+    class BlobStorage : IBlobStorage
     {
-        private readonly IEnviroment enviroment;
+        readonly IEnviroment enviroment;
 
-        public BlobStorage(IEnviroment enviroment)
-        {
-            Contract.Assert(enviroment != null);
-
-            this.enviroment = enviroment;
-        }
+        public BlobStorage(IEnviroment enviroment) => this.enviroment = enviroment;
 
         public async Task UploadAsync(byte[] bytes, string containerName, string blobName)
         {

--- a/Services/ILanguageUnderstanding.cs
+++ b/Services/ILanguageUnderstanding.cs
@@ -14,15 +14,13 @@ namespace NosAyudamos
         Task<IEnumerable<string>> GetIntentsAsync(string? text);
     }
 
-    public class LanguageUnderstanding : ILanguageUnderstanding
+    class LanguageUnderstanding : ILanguageUnderstanding
     {
         readonly IEnviroment enviroment;
         readonly ILogger<LanguageUnderstanding> logger;
 
         public LanguageUnderstanding(IEnviroment enviroment, ILogger<LanguageUnderstanding> logger)
         {
-            Contract.Assert(enviroment != null);
-
             this.enviroment = enviroment;
             this.logger = logger;
         }

--- a/Services/IMessaging.cs
+++ b/Services/IMessaging.cs
@@ -1,4 +1,6 @@
-using System.Diagnostics.Contracts;
+using System;
+using System.Net.Http;
+using System.Net.Http.Formatting;
 using System.Threading.Tasks;
 using Twilio;
 using Twilio.Rest.Api.V2010.Account;
@@ -7,28 +9,74 @@ namespace NosAyudamos
 {
     public interface IMessaging
     {
-        Task<string> SendTextAsync(string from, string body, string to);
+        Task SendTextAsync(string from, string body, string to);
     }
 
-    public class TwilioMessaging : IMessaging
+    class Messaging : IMessaging, IDisposable
+    {
+        Lazy<IMessaging> twilio;
+        Lazy<IMessaging> chatApi;
+        string chatApiNumber;
+
+        public Messaging(IEnviroment enviroment)
+        {
+            chatApiNumber = enviroment.GetVariable("ChatApiNumber");
+            twilio = new Lazy<IMessaging>(() => new TwilioMessaging(enviroment));
+            chatApi = new Lazy<IMessaging>(() => new ChatApiMessaging(enviroment));
+        }
+
+        public void Dispose()
+        {
+            if (chatApi.IsValueCreated && chatApi.Value is IDisposable cd)
+                cd.Dispose();
+
+            if (twilio.IsValueCreated && twilio.Value is IDisposable td)
+                td.Dispose();
+        }
+
+        public Task SendTextAsync(string from, string body, string to)
+        {
+            if (from == chatApiNumber)
+                return chatApi.Value.SendTextAsync(from, body, to);
+            else
+                return twilio.Value.SendTextAsync(from, body, to);
+        }
+    }
+
+    class ChatApiMessaging : IMessaging
+    {
+        readonly MediaTypeFormatter formatter = new JsonMediaTypeFormatter();
+        string apiUrl;
+
+        public ChatApiMessaging(IEnviroment enviroment)
+        {
+            apiUrl = enviroment.GetVariable("ChatApiUrl");
+        }
+
+        public async Task SendTextAsync(string from, string body, string to)
+        {
+            using var http = new HttpClient();
+            await http.PostAsync(apiUrl, new { phone = to.TrimStart('+'), body }, formatter).ConfigureAwait(false);
+        }
+    }
+
+    class TwilioMessaging : IMessaging
     {
         public TwilioMessaging(IEnviroment enviroment)
         {
-            Contract.Assert(enviroment != null);
-
             TwilioClient.Init(
                 enviroment.GetVariable("TwilioAccountSid"),
                 enviroment.GetVariable("TwilioAuthToken"));
         }
 
-        public async Task<string> SendTextAsync(string from, string body, string to)
+        public async Task SendTextAsync(string from, string body, string to)
         {
             var message = await MessageResource.CreateAsync(
                from: new Twilio.Types.PhoneNumber(from),
                to: new Twilio.Types.PhoneNumber(to),
                body: body).ConfigureAwait(false);
 
-            return message.Sid;
+            //return message.Sid;
         }
     }
 }

--- a/Services/ITextAnalysis.cs
+++ b/Services/ITextAnalysis.cs
@@ -13,16 +13,11 @@ namespace NosAyudamos
         Task<IEnumerable<CategorizedEntity>> GetEntitiesAsync(string? text);
     }
 
-    public class TextAnalysis : ITextAnalysis
+    class TextAnalysis : ITextAnalysis
     {
         private readonly IEnviroment enviroment;
 
-        public TextAnalysis(IEnviroment enviroment)
-        {
-            Contract.Assert(enviroment != null);
-
-            this.enviroment = enviroment;
-        }
+        public TextAnalysis(IEnviroment enviroment) => this.enviroment = enviroment;
 
         public async Task<IEnumerable<string>> GetKeyPhrasesAsync(string? text)
         {

--- a/Startup.cs
+++ b/Startup.cs
@@ -10,12 +10,10 @@ using Serilog.Sinks.Slack;
 
 namespace NosAyudamos
 {
-    public class Startup : FunctionsStartup
+    class Startup : FunctionsStartup
     {
         public override void Configure(IFunctionsHostBuilder builder)
         {
-            Contract.Assert(builder != null);
-
             var logger = new LoggerConfiguration()
                 .MinimumLevel.Information()
                 .MinimumLevel.Override("Host", LogEventLevel.Warning)
@@ -41,7 +39,7 @@ namespace NosAyudamos
             builder.Services.AddLogging(lb => lb.AddSerilog(logger));
             builder.Services.AddApplicationInsightsTelemetry();
             builder.Services.AddSingleton<IEnviroment, Enviroment>();
-            builder.Services.AddSingleton<IMessaging, TwilioMessaging>();
+            builder.Services.AddSingleton<IMessaging, Messaging>();
             builder.Services.AddSingleton<ILanguageUnderstanding, LanguageUnderstanding>();
             builder.Services.AddSingleton<ITextAnalysis, TextAnalysis>();
             builder.Services.AddSingleton<IPersonRecognizer, PersonRecognizer>();


### PR DESCRIPTION
Based on the number where the message was received, we
send responses via Twilio or ChatApi, automatically.

We fixed the validation of Twilio requests, and also
fixed the body parsing which was incorrectly assuming
that Twilio would be sending JSON, which is not the case.

The body sent by Twilio is also UrlEncoded, so we encode
the ChatApi body too.

Also, for whatever reason, ChatApi is re-entrant when
we send messages too, so we had to account for that
specifically too.

Finally, it turned out that none of our `Contracts`
where really needed since only public classes must
validate for null. Making everything internal makes
the warnings about validating for non-null parameters
go away.