### PR TITLE
Conditional tests for event grid learning

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -13,15 +13,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
+    - name: Use dotnet
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
-    - name: Setup dotnet-format
+    - name: Use dotnet-format
       run: dotnet tool update -g --version 3.2.* dotnet-format >nul || dotnet tool list -g
+    - name: Env
+      run: 'gci env: | format-table -autosize -wrap'
+      shell: pwsh
     - name: Run dotnet-format
       run: dotnet format -f . --dry-run --check -v:diag
-    - name: Install dependencies
+    - name: Restore
       run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore

--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="3.0.0-beta*" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.6.*" />
     <PackageReference Include="netfx-System.StringResources" Version="3.2.0-alpha" />
+    <PackageReference Include="Microsoft.Azure.EventGrid" Version="3.2.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Api/Functions/EventGridLogger.cs
+++ b/Api/Functions/EventGridLogger.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.EventGrid.Models;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Serilog;
+
+namespace NosAyudamos
+{
+    class EventGridLogger
+    {
+        [FunctionName("eventlogger")]
+        public async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "options", "post", Route = null)] HttpRequest req,
+            ILogger logger)
+        {
+            if (req.Method.Equals("options", StringComparison.OrdinalIgnoreCase) &&
+                req.Headers.TryGetValue("WebHook-Request-Callback", out var values) &&
+                values.Count == 1 &&
+                Uri.TryCreate(values[0], UriKind.Absolute, out var callback))
+            {
+                var code = callback.ParseQueryString().Get("id");
+                return new OkObjectResult(new SubscriptionValidationResponse
+                {
+                    ValidationResponse = code
+                });
+            }
+
+            using var reader = new StreamReader(req.Body);
+            var body = await reader.ReadToEndAsync();
+
+            logger.Information(JsonSerializer.Serialize(JsonDocument.Parse(body).RootElement, new JsonSerializerOptions { WriteIndented = true, Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping }));
+
+            return new OkObjectResult("");
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # api.nosayudamos.org
+
+// TODO

--- a/UnitTests/EventGridTests.cs
+++ b/UnitTests/EventGridTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Microsoft.Azure.EventGrid;
+using Microsoft.Azure.EventGrid.Models;
+using Microsoft.AspNetCore.Testing;
+
+namespace NosAyudamos
+{
+    public class EventGridTests
+    {
+        Uri gridUri;
+        string gridKey;
+
+        public EventGridTests()
+        {
+            if (File.Exists("local.settings.json"))
+            {
+                dynamic settings = JObject.Parse(File.ReadAllText("local.settings.json"));
+                gridUri = new Uri((string)settings.Values.EventGridUrl);
+                gridKey = settings.Values.EventGridAccessKey;
+            }
+        }
+
+        [SkipOnCI]
+        [ConditionalFact]
+        public async Task SendCustomEvent()
+        {
+            var domain = gridUri.Host;
+            var credentials = new TopicCredentials(gridKey);
+            using var client = new EventGridClient(credentials);
+
+            await client.PublishEventsAsync(domain, new List<EventGridEvent>
+            {
+                new EventGridEvent
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Topic = "NosAyudamos.Inbox",
+                    EventType = "NosAyudamos.Messaging",
+                    EventTime = DateTime.Now,
+                    Subject = "23696294",
+                    Data = "{ \"body\": \"ayuda\" }",
+                    DataVersion = "1.0",
+                }
+            });
+        }
+    }
+}

--- a/UnitTests/GlobalSuppressions.cs
+++ b/UnitTests/GlobalSuppressions.cs
@@ -1,0 +1,15 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Tests")]
+[assembly: SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Tests")]
+[assembly: SuppressMessage("Style", "IDE0021:Use expression body for constructors", Justification = "Tests")]
+[assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods", Justification = "Tests")]
+[assembly: SuppressMessage("Globalization", "CA1304:Specify CultureInfo", Justification = "Tests")]
+[assembly: SuppressMessage("Design", "CA1812:Internal class never instantiated", Justification = "Tests")]
+[assembly: SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "Tests")]
+[assembly: SuppressMessage("Usage", "CA2243:Attribute string literals should parse correctly", Justification = "Tests")]

--- a/UnitTests/Testing/ConditionalFactAttribute.cs
+++ b/UnitTests/Testing/ConditionalFactAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.AspNetCore.Testing
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [XunitTestCaseDiscoverer("Microsoft.AspNetCore.Testing." + nameof(ConditionalFactDiscoverer), "UnitTests")]
+    public class ConditionalFactAttribute : FactAttribute
+    {
+    }
+}

--- a/UnitTests/Testing/ConditionalFactDiscoverer.cs
+++ b/UnitTests/Testing/ConditionalFactDiscoverer.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+// Do not change this namespace without changing the usage in ConditionalFactAttribute
+namespace Microsoft.AspNetCore.Testing
+{
+    internal class ConditionalFactDiscoverer : FactDiscoverer
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public ConditionalFactDiscoverer(IMessageSink diagnosticMessageSink)
+            : base(diagnosticMessageSink)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            var skipReason = testMethod.EvaluateSkipConditions();
+            return skipReason != null
+                ? new SkippedTestCase(skipReason, _diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), TestMethodDisplayOptions.None, testMethod)
+                : base.CreateTestCase(discoveryOptions, testMethod, factAttribute);
+        }
+    }
+}

--- a/UnitTests/Testing/EnvironmentVariableSkipConditionAttribute.cs
+++ b/UnitTests/Testing/EnvironmentVariableSkipConditionAttribute.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Testing
+{
+    /// <summary>
+    /// Skips a test when the value of an environment variable matches any of the supplied values.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true)]
+    public class EnvironmentVariableSkipConditionAttribute : Attribute, ITestCondition
+    {
+        private readonly string _variableName;
+        private readonly string[] _values;
+        private string _currentValue;
+        private readonly IEnvironmentVariable _environmentVariable;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="EnvironmentVariableSkipConditionAttribute"/>.
+        /// </summary>
+        /// <param name="variableName">Name of the environment variable.</param>
+        /// <param name="values">Value(s) of the environment variable to match for the test to be skipped</param>
+        public EnvironmentVariableSkipConditionAttribute(string variableName, params string[] values)
+            : this(new EnvironmentVariable(), variableName, values)
+        {
+        }
+
+        // To enable unit testing
+        internal EnvironmentVariableSkipConditionAttribute(
+            IEnvironmentVariable environmentVariable,
+            string variableName,
+            params string[] values)
+        {
+            if (environmentVariable == null)
+            {
+                throw new ArgumentNullException(nameof(environmentVariable));
+            }
+            if (variableName == null)
+            {
+                throw new ArgumentNullException(nameof(variableName));
+            }
+            if (values == null)
+            {
+                throw new ArgumentNullException(nameof(values));
+            }
+
+            _variableName = variableName;
+            _values = values;
+            _environmentVariable = environmentVariable;
+        }
+
+        /// <summary>
+        /// Runs the test only if the value of the variable matches any of the supplied values. Default is <c>True</c>.
+        /// </summary>
+        public bool RunOnMatch { get; set; } = true;
+
+        public bool IsMet
+        {
+            get
+            {
+                _currentValue = _environmentVariable.Get(_variableName);
+                var hasMatched = _values.Any(value => string.Compare(value, _currentValue, ignoreCase: true) == 0);
+
+                if (RunOnMatch)
+                {
+                    return hasMatched;
+                }
+                else
+                {
+                    return !hasMatched;
+                }
+            }
+        }
+
+        public string SkipReason
+        {
+            get
+            {
+                var value = _currentValue == null ? "(null)" : _currentValue;
+                return $"Test skipped on environment variable with name '{_variableName}' and value '{value}' " +
+                    $"for the '{nameof(RunOnMatch)}' value of '{RunOnMatch}'.";
+            }
+        }
+
+        private struct EnvironmentVariable : IEnvironmentVariable
+        {
+            public string Get(string name)
+            {
+                return Environment.GetEnvironmentVariable(name);
+            }
+        }
+    }
+}

--- a/UnitTests/Testing/IEnvironmentVariable.cs
+++ b/UnitTests/Testing/IEnvironmentVariable.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.AspNetCore.Testing
+{
+    internal interface IEnvironmentVariable
+    {
+        string Get(string name);
+    }
+}

--- a/UnitTests/Testing/ITestCondition.cs
+++ b/UnitTests/Testing/ITestCondition.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.AspNetCore.Testing
+{
+    public interface ITestCondition
+    {
+        bool IsMet { get; }
+
+        string SkipReason { get; }
+    }
+}

--- a/UnitTests/Testing/SkipOnCIAttribute.cs
+++ b/UnitTests/Testing/SkipOnCIAttribute.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Testing
+{
+    /// <summary>
+    /// Skip test if running on CI
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
+    public class SkipOnCIAttribute : Attribute, ITestCondition
+    {
+        public SkipOnCIAttribute(string issueUrl = "")
+        {
+            IssueUrl = issueUrl;
+        }
+
+        public string IssueUrl { get; }
+
+        public bool IsMet
+        {
+            get
+            {
+                return !OnCI();
+            }
+        }
+
+        public string SkipReason
+        {
+            get
+            {
+                return $"This test is skipped on CI";
+            }
+        }
+
+        public static bool OnCI() => (bool.TryParse(Environment.GetEnvironmentVariable("CI"), out var ci) && ci) || OnHelix() || OnAzdo();
+        public static bool OnHelix() => !string.IsNullOrEmpty(GetTargetHelixQueue());
+        public static string GetTargetHelixQueue() => Environment.GetEnvironmentVariable("helix");
+        public static bool OnAzdo() => !string.IsNullOrEmpty(GetIfOnAzdo());
+        public static string GetIfOnAzdo() => Environment.GetEnvironmentVariable("AGENT_OS") + Environment.GetEnvironmentVariable("TF_BUILD");
+    }
+}

--- a/UnitTests/Testing/SkippedTestCase.cs
+++ b/UnitTests/Testing/SkippedTestCase.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.AspNetCore.Testing
+{
+    public class SkippedTestCase : XunitTestCase
+    {
+        private string _skipReason;
+
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public SkippedTestCase() : base()
+        {
+        }
+
+        public SkippedTestCase(
+            string skipReason,
+            IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay,
+            TestMethodDisplayOptions defaultMethodDisplayOptions,
+            ITestMethod testMethod,
+            object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
+        {
+            _skipReason = skipReason;
+        }
+
+        protected override string GetSkipReason(IAttributeInfo factAttribute)
+            => _skipReason ?? base.GetSkipReason(factAttribute);
+
+        public override void Deserialize(IXunitSerializationInfo data)
+        {
+            _skipReason = data.GetValue<string>(nameof(_skipReason));
+
+            // We need to call base after reading our value, because Deserialize will call
+            // into GetSkipReason.
+            base.Deserialize(data);
+        }
+
+        public override void Serialize(IXunitSerializationInfo data)
+        {
+            base.Serialize(data);
+            data.AddValue(nameof(_skipReason), _skipReason);
+        }
+    }
+}

--- a/UnitTests/Testing/TestMethodExtensions.cs
+++ b/UnitTests/Testing/TestMethodExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.AspNetCore.Testing
+{
+    public static class TestMethodExtensions
+    {
+        public static string EvaluateSkipConditions(this ITestMethod testMethod)
+        {
+            var testClass = testMethod.TestClass.Class;
+            var assembly = testMethod.TestClass.TestCollection.TestAssembly.Assembly;
+            var conditionAttributes = testMethod.Method
+                .GetCustomAttributes(typeof(ITestCondition))
+                .Concat(testClass.GetCustomAttributes(typeof(ITestCondition)))
+                .Concat(assembly.GetCustomAttributes(typeof(ITestCondition)))
+                .OfType<ReflectionAttributeInfo>()
+                .Select(attributeInfo => attributeInfo.Attribute);
+
+            foreach (ITestCondition condition in conditionAttributes)
+            {
+                if (!condition.IsMet)
+                {
+                    return condition.SkipReason;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -7,14 +7,25 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="..\Api\local.settings.json" Link="local.settings.json" Condition="Exists('..\Api\local.settings.json')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="*" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Api\Api.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Testing\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Uses conditional unit tests helpers from ASP.NET core

From https://github.com/dotnet/runtime/tree/master/src/libraries/Common/tests/Extensions/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit.

This allows us to skip the local-only manual tests.

Also add sample event handler with support for authenticating
the subscription, which is required to allow subscribing the
function to an event domain.