### PR TITLE
Add build information to assemblies for troubleshooting

### DIFF
--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -217,7 +217,7 @@ namespace NosAyudamos
                 new EventGridEvent
                 {
                     Id = now.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture),
-                    EventType = e.GetType().FullName,
+                    EventType = "System.Exception",
                     EventTime = now,
                     Data = new Serializer().Serialize(e),
                     DataVersion = typeof(Startup).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ??

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <LangVersion>Preview</LangVersion>
+    <InformationalVersion Condition="'$(TF_BUILD)' == 'true'">$(BUILD_BUILDNUMBER)-$(BUILD_BUILDID).$(BUILD_SOURCEBRANCHNAME).$(BUILD_SOURCEVERSION.Substring(0, 9))</InformationalVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
When startup exceptions, we append this information so we
can track the build that resulted in the given error being
reported.